### PR TITLE
Update README, use `int` in enums and flags by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@
 
 Imagine you're developing C library and already have more than 50 functions. Sometimes you change signatures of old functions or rename them. It'll be headache to write and support all [ctypes](https://docs.python.org/3/library/ctypes.html)-declarations for Python wrapper. **annotatec** will create all Python objects for you. All you need is to provide declarations, which can be placed directly into your C code.
 
+## How to install
+
+This library can be installed with `pip`:
+
+```bash
+pip install annotatec
+```
+
+Or build it and install yourself:
+
+```bash
+pip install git+https://github.com/lynnporu/annotatec.git#egg=annotatec
+```
+
 ## Minimal livable example
 
 You have some library `lib.c` and it's header `lib.h`. These files were compiled into `lib.so` (or `lib.dll` in Windows).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://github.com/lynnporu/annotatec/raw/dev/logo.png">
 </p>
 
-![PyPI](https://img.shields.io/pypi/v/annotatec)
+[![PyPI](https://img.shields.io/pypi/v/annotatec.svg)](https://pypi.python.org/pypi/annotatec)
 ![GitHub repo size](https://img.shields.io/github/repo-size/lynnporu/annotatec)
 ![GitHub](https://img.shields.io/github/license/lynnporu/annotatec)
 

--- a/annotatec/loader.py
+++ b/annotatec/loader.py
@@ -40,3 +40,26 @@ class Loader:
 
     def __getattr__(self, key):
         return self.parser.declarations.compile(key)
+
+    @property
+    def ref(self):
+        """Get pointer of any next objects.
+
+        Example:
+            Support `loader.obj` evaluates to `int`. That means,
+            `loader.ref.obj` will be evaluated to `ctypes.POINTER(int)`.
+        """
+        class referencer:
+            def __init__(referencer_self, loader_self, depth: int = 1):
+                referencer_self.depth = depth
+                referencer_self.loader = loader_self
+
+            def __getattr__(self, key):
+                return self.loader.parser.declarations.compile(
+                    key + ("*" * self.depth))
+
+            @property
+            def ref(self):
+                return referencer(self.loader, self.depth + 1)
+
+        return referencer(loader_self=self, depth=1)

--- a/annotatec/parser.py
+++ b/annotatec/parser.py
@@ -219,10 +219,9 @@ class EnumDeclaration(Declaration, MembersDeclaration):
             raise ParserError(
                 "Struct declaration must have exactly 2 values for @member.")
 
-        if not type_unit:
-            self.enum_type = BASE_C_TYPES["int"]
-        else:
-            self.enum_type = type_unit[0]
+        self.enum_type = (
+            BASE_C_TYPES["int"] if not type_unit else type_unit[0]
+        )
 
         self.members = {name: eval(value) for name, value in member_units}
 
@@ -247,15 +246,14 @@ class FlagsDeclaration(Declaration, MembersDeclaration):
     ):
         super().__init__(namespace, name)
 
-        if len(type_unit) != 1:
-            raise ParserError(
-                "Flags declaration must have one value for @type.")
-
         if any(len(member) != 2 for member in flag_units):
             raise ParserError(
                 "Flags declaration must have exactly 2 values for @flag.")
 
-        self.flags_type = type_unit[0]
+        self.flags_type = (
+            BASE_C_TYPES["int"] if not type_unit else type_unit[0]
+        )
+
         self.members = {name: eval(value) for name, value in flag_units}
 
     def compile(self):

--- a/annotatec/parser.py
+++ b/annotatec/parser.py
@@ -211,7 +211,7 @@ class EnumDeclaration(Declaration, MembersDeclaration):
     def __init__(
         self,
         namespace: DeclarationsNamespace, name: str,
-        type_unit: UnitValues, member_units: UnitValuesList
+        member_units: UnitValuesList, type_unit: UnitValues = None
     ):
         super().__init__(namespace, name)
 
@@ -219,7 +219,11 @@ class EnumDeclaration(Declaration, MembersDeclaration):
             raise ParserError(
                 "Struct declaration must have exactly 2 values for @member.")
 
-        self.enum_type = type_unit[0]
+        if not type_unit:
+            self.enum_type = BASE_C_TYPES["int"]
+        else:
+            self.enum_type = type_unit[0]
+
         self.members = {name: eval(value) for name, value in member_units}
 
     def compile(self):


### PR DESCRIPTION
This PR resolve #2, resolve #4.

There's also `ref` property to `Loader` was being added. This should probably be deleted because it may collide with some library's function named `ref`.