### PR TITLE
Forbid to change global variables

### DIFF
--- a/annotatec/declarations.py
+++ b/annotatec/declarations.py
@@ -226,26 +226,29 @@ class MembersDeclaration:
         return self.members[key]
 
 
-class MembersWrapper:
+class DeclarationWrapper:
 
     def __init__(self, subject, wrapper):
         self.subject = subject
         self.wrapper = wrapper
+
+    def __call__(self, *args, **kwargs):
+        return self.subject.__call__(*args, **kwargs)
+
+    def __mul__(self, amount):
+        return MembersWrapper(
+            subject=(self.subject.__mul__(amount)),
+            wrapper=self.wrapper
+        )
+
+
+class MembersWrapper(DeclarationWrapper):
 
     def __getattr__(self, key):
         try:
             return getattr(self.wrapper, key)
         except KeyError:
             return getattr(self.subject, key)
-
-    def __call__(self, *args, **kwargs):
-        return self.subject(*args, **kwargs)
-
-    def __mul__(self, amount):
-        return MembersWrapper(
-            subject=(self.subject * amount),
-            wrapper=self.wrapper
-        )
 
 
 class StructDeclaration(Declaration, MembersDeclaration):

--- a/annotatec/loader.py
+++ b/annotatec/loader.py
@@ -3,6 +3,7 @@ import typing
 
 from . import libtypes
 from . import parser
+from . import declarations
 
 
 class Loader:
@@ -47,6 +48,15 @@ class Loader:
 
     def __getattr__(self, key):
         return self.parser.declarations.compile(key)
+
+    def __setattr__(self, key, value):
+        compiled = self.parser.declarations.compile(key)
+        if isinstance(compiled, declarations.VariableDeclaration):
+            raise ValueError(
+                f"Better implement setter function for `{key}` global "
+                "variable.")
+        else:
+            raise RuntimeError(f"`{key}` is not a variable")
 
     def parse_sources(
         self,


### PR DESCRIPTION
This PR contains:
- `MembersWrapper` are now abstracted from `DeclarationWrapper`
- Global variables are now illegal to be changes directly and user is asked to implement a setter.

This PR is related to #8, but not fixes it. Maybe it will be wiser to fix it after #6, because resulting logic may be a little confusing.